### PR TITLE
Add stereo flag support

### DIFF
--- a/src/VR.js
+++ b/src/VR.js
@@ -241,12 +241,18 @@ class VRDisplay extends EventTarget {
   }
 
   getLayers() {
-    return [
+    return GlobalContext.xrState.stereo[0] ? [
       {
         leftBounds: [0, 0, 0.5, 1],
         rightBounds: [0.5, 0, 0.5, 1],
         source: null,
-      }
+      },
+    ] : [
+      {
+        leftBounds: [0, 0, 1, 1],
+        rightBounds: [1, 0, 1, 1],
+        source: null,
+      },
     ];
   }
 
@@ -258,8 +264,18 @@ class VRDisplay extends EventTarget {
       upDegrees: fovArray[2],
       downDegrees: fovArray[3],
     });
+    let renderWidth;
+    if (GlobalContext.xrState.stereo[0]) {
+      renderWidth = GlobalContext.xrState.renderWidth[0];
+    } else {
+      if (eye === 'left') {
+        renderWidth = GlobalContext.xrState.renderWidth[0] * 2;
+      } else {
+        renderWidth = 0;
+      }
+    }
     return {
-      renderWidth: GlobalContext.xrState.renderWidth[0],
+      renderWidth,
       renderHeight:  GlobalContext.xrState.renderHeight[0],
       offset: leftEye ? GlobalContext.xrState.leftOffset : GlobalContext.xrState.rightOffset,
       fieldOfView: _fovArrayToVRFieldOfView(leftEye ? GlobalContext.xrState.leftFov : GlobalContext.xrState.rightFov),
@@ -642,6 +658,12 @@ class FakeXRDisplay {
     return GlobalContext.xrState.leftViewMatrix;
   }
   set viewMatrix(viewMatrix) {}
+  get stereo() {
+    return GlobalContext.xrState.stereo[0];
+  }
+  set stereo(stereo) {
+    GlobalContext.xrState.stereo[0] = stereo ? 1 : 0;
+  }
 }
 
 const hmdTypes = [

--- a/src/XR.js
+++ b/src/XR.js
@@ -418,7 +418,11 @@ class XRViewport {
     this.eye = eye;
   }
   get x() {
-    return this.eye === 'left' ? 0 : GlobalContext.xrState.renderWidth[0];
+    if (GlobalContext.xrState.stereo[0]) {
+      return this.eye === 'left' ? 0 : GlobalContext.xrState.renderWidth[0];
+    } else {
+      return this.eye === 'left' ? 0 : GlobalContext.xrState.renderWidth[0] * 2;
+    }
   }
   set x(x) {}
   get y() {
@@ -426,7 +430,15 @@ class XRViewport {
   }
   set y(y) {}
   get width() {
-    return GlobalContext.xrState.renderWidth[0];
+    if (GlobalContext.xrState.stereo[0]) {
+      return GlobalContext.xrState.renderWidth[0];
+    } else {
+      if (this.eye === 'left') {
+        return GlobalContext.xrState.renderWidth[0] * 2;
+      } else {
+        return 0;
+      }
+    }
   }
   set width(width) {}
   get height() {

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,8 @@ const xrState = (() => {
   result.metrics[1] = window.innerHeight;
   result.devicePixelRatio = _makeTypedArray(Float32Array, 1);
   result.devicePixelRatio[0] = window.devicePixelRatio;
+  result.stereo = _makeTypedArray(Uint32Array, 1);
+  // result.stereo[0] = 1;
   result.depthNear = _makeTypedArray(Float32Array, 1);
   result.depthNear[0] = 0.1;
   result.depthFar = _makeTypedArray(Float32Array, 1);

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -145,6 +145,7 @@ class XRIFrame extends HTMLElement {
             })();
             
             GlobalContext.xrState.isPresentingReal[0] = 1;
+            GlobalContext.xrState.stereo[0] = 1;
             GlobalContext.xrState.renderWidth[0] = width;
             GlobalContext.xrState.renderHeight[0] = height;
             


### PR DESCRIPTION
This adds a `stereo` flag to the `FakeXRDisplay`, which defaults to `false`.

This works by flattening the fake viewport eyes into the left one. Although there are still two eyes (for compatibility), the right one is collapsed to width zero and only the left one is effectively used for drawing pixels.

There should be no change in performance.

Fixes https://github.com/exokitxr/exokit-web/issues/7.