### PR TITLE
Add local-floor reference space default

### DIFF
--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -125,7 +125,7 @@ class XRIFrame extends HTMLElement {
       if (!win.session) {
         if (win.canvas) {
           const session = await navigator.xr.requestSession('immersive-vr', {
-            optionalFeatures: ['local-floor', 'bounded-floor'],
+            requiredFeatures: ['local-floor'],
           });
           let referenceSpace;
           try {

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -131,6 +131,7 @@ class XRIFrame extends HTMLElement {
           try {
             referenceSpace = await session.requestReferenceSpace('local-floor');
           } catch (err) {
+            console.warn(err);
             referenceSpace = await session.requestReferenceSpace('local');
           }
           const baseLayer = new XRWebGLLayer(session, win.ctx);

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -124,9 +124,17 @@ class XRIFrame extends HTMLElement {
       const {contentWindow: win} = this;
       if (!win.session) {
         if (win.canvas) {
-          const session = await navigator.xr.requestSession('immersive-vr');
-          let referenceSpace = await session.requestReferenceSpace('local');
-          referenceSpace = referenceSpace.getOffsetReferenceSpace(new XRRigidTransform(new DOMPoint(0, -1.6, 0))); // hack: should use local-floor space
+          const session = await navigator.xr.requestSession('immersive-vr', {
+            optionalFeatures: ['local-floor', 'bounded-floor'],
+          });
+          let referenceSpace = null;
+          try {
+            referenceSpace = await session.requestReferenceSpace('local-floor');
+          } catch (err) {}
+          if (!referenceSpace) {
+            referenceSpace = await session.requestReferenceSpace('local');
+            referenceSpace = referenceSpace.getOffsetReferenceSpace(new XRRigidTransform(new DOMPoint(0, -1.6, 0)));
+          }
           const baseLayer = new XRWebGLLayer(session, win.ctx);
           
           session.updateRenderState({baseLayer});

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -127,13 +127,11 @@ class XRIFrame extends HTMLElement {
           const session = await navigator.xr.requestSession('immersive-vr', {
             optionalFeatures: ['local-floor', 'bounded-floor'],
           });
-          let referenceSpace = null;
+          let referenceSpace;
           try {
             referenceSpace = await session.requestReferenceSpace('local-floor');
-          } catch (err) {}
-          if (!referenceSpace) {
+          } catch (err) {
             referenceSpace = await session.requestReferenceSpace('local');
-            referenceSpace = referenceSpace.getOffsetReferenceSpace(new XRRigidTransform(new DOMPoint(0, -1.6, 0)));
           }
           const baseLayer = new XRWebGLLayer(session, win.ctx);
           


### PR DESCRIPTION
Per https://github.com/mrdoob/three.js/pull/17429/files#diff-4488c2b5394be3dc8ef1cdeeaf06d72cR102, add the optional feature flag for `local-floor` support.

We fall back to `local` reference space.