### PR TITLE
Canvas viewport transclusion

### DIFF
--- a/src/Graphics.js
+++ b/src/Graphics.js
@@ -187,6 +187,10 @@ Object.defineProperty(HTMLCanvasElement.prototype, 'clientHeight', {
     return this.height;
   },
 });
+HTMLCanvasElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+  const {canvasViewport} = GlobalContext.xrState;
+  return new DOMRect(canvasViewport[0], canvasViewport[1], canvasViewport[2], canvasViewport[3]);
+};
 
 [WebGLRenderingContext, WebGL2RenderingContext].forEach(WebGLRenderingContext => {
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,8 @@ const xrState = (() => {
   result.devicePixelRatio[0] = window.devicePixelRatio;
   result.stereo = _makeTypedArray(Uint32Array, 1);
   // result.stereo[0] = 1;
+  result.canvasViewport = _makeTypedArray(Float32Array, 4);
+  result.canvasViewport.set(Float32Array.from([0, 0, window.innerWidth, window.innerHeight]));
   result.depthNear = _makeTypedArray(Float32Array, 1);
   result.depthNear[0] = 0.1;
   result.depthFar = _makeTypedArray(Float32Array, 1);

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -56,6 +56,13 @@ class XRIFrame extends HTMLElement {
             win.canvas.height = GlobalContext.xrState.renderHeight[0];
             win.canvas.style.width = '100%';
             win.canvas.style.height = '100%';
+            win.canvas.addEventListener('mouseenter', e => {
+              const {x, y, width, height} = win.canvas.getBoundingClientRect();
+              GlobalContext.xrState.canvasViewport[0] = x;
+              GlobalContext.xrState.canvasViewport[1] = y;
+              GlobalContext.xrState.canvasViewport[2] = width;
+              GlobalContext.xrState.canvasViewport[3] = height;
+            });
             win.ctx = win.canvas.getContext('webgl2', {
               xrCompatible: true,
             });


### PR DESCRIPTION
Fixes #16.

This PR fixes that by proxying the top-level canvas viewport into the internal `getBoundingClientRect` calls.

The viewport is captured during `mouseenter`, which should be good enough for any case that doesn't animate the `<canvas>` around the page while the user is interacting with it -- which would be pretty weird.