### PR TITLE
SharedArrayBuffer -> ArrayBuffer

### DIFF
--- a/src/XR.js
+++ b/src/XR.js
@@ -546,7 +546,7 @@ GlobalContext.XRInputSourceEvent = XRInputSourceEvent;
 
 class XRRigidTransform {
   constructor(position, orientation, scale) {
-    if (position && position.constructor && position.constructor.name === 'SharedArrayBuffer') {
+    if (typeof position == 'object') {
       const inverse = orientation instanceof XRRigidTransform ? orientation : null;
 
       this.initialize(position, inverse);

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ GlobalContext.windows = windows;
 
 const xrState = (() => {
   const _makeSab = size => {
-    const sab = new SharedArrayBuffer(size);
+    const sab = new ArrayBuffer(size);
     let index = 0;
     return (c, n) => {
       const result = new c(sab, index, n);


### PR DESCRIPTION
It turns out due to how we construct the initial seed message for child windows, we can pass the `SharedArrayBuffer` containing the `XRState` by direct reference. This means it can be a pure `ArrayBuffer`.

Making the switch removes all reference of `SharedArrayBuffer` in the codebase so it _should_ work in environments that blocked `SharedArrayBuffer`.

Fixes https://github.com/exokitxr/exokit-web/issues/43.