### PR TITLE
Synchronous cross-window postMessage

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -687,21 +687,25 @@ self.onrunasync = req => {
   switch (method) {
     case 'tickAnimationFrame': {
       self.tickAnimationFrame(req);
-      return Promise.resolve();
+      break;
     }
     case 'enterXr': {
       console.log('handle enter xr', GlobalContext.id);
       self.vrdisplaypresentchange();
-      return Promise.all(windows.map(win => win.runAsync({
-        method: 'enterXr',
-      }))).then(() => {});
+      for (let i = 0; i < windows.length; i++) {
+        windows[i].runAsync({
+          method: 'enterXr',
+        });
+      }
       break;
     }
     case 'exitXr': {
       self.vrdisplaypresentchange();
-      return Promise.all(windows.map(win => win.runAsync({
-        method: 'exitXr',
-      }))).then(() => {});
+      for (let i = 0; i < windows.length; i++) {
+        windows[i].runAsync({
+          method: 'exitXr',
+        });
+      }
       break;
     }
     case 'response': {
@@ -710,10 +714,8 @@ self.onrunasync = req => {
       if (keypath.length === 0) {
         if (vrPresentState.responseAccepts.length > 0) {
           vrPresentState.responseAccepts.shift()(req);
-
-          return Promise.resolve();
         } else {
-          return Promise.reject(new Error(`unexpected response at window ${method}`));
+          throw new Error(`unexpected response at window ${method}`);
         }
       } else {
         const windowId = keypath.pop();
@@ -729,8 +731,8 @@ self.onrunasync = req => {
         } else {
           console.warn('ignoring unknown response', req, {windowId});
         }
-        return Promise.resolve();
       }
+      break;
     }
     /* case 'keyEvent': {
       const {event} = request;
@@ -806,9 +808,11 @@ self.onrunasync = req => {
       }
       break;
     } */
-    case 'eval': // used in tests
-      return Promise.resolve([(0, eval)(req.scriptString), []]);
+    case 'eval': {// used in tests
+      (0, eval)(req.scriptString);
+      break;
+    }
     default:
-      return Promise.reject(new Error(`invalid window async request: ${JSON.stringify(req)}`));
+      throw new Error(`invalid window async request: ${JSON.stringify(req)}`);
   }
 };

--- a/src/WindowBase.js
+++ b/src/WindowBase.js
@@ -141,7 +141,7 @@ const _oninitmessage = async e => {
     self._onbootstrap = undefined;
   };
   self._postMessageUp = function _postMessageUp(data, transfer) {
-    messagePort.postMessage(data, transfer);
+    messagePort.postMessageSync(data, transfer);
   };
   const _onmessageHandle = e => {
     const {data: m} = e;
@@ -163,26 +163,23 @@ const _oninitmessage = async e => {
         break;
       }
       case 'runAsync': {
-        let result, err;
+        let resultSpec, err;
         try {
-          result = self.onrunasync ? self.onrunasync(m.request) : null;
+          resultSpec = self.onrunasync ? self.onrunasync(m.request) : null;
         } catch(e) {
           err = e.stack;
         }
         if (!err) {
-          Promise.resolve(result)
-            .then(resultSpec => {
-              let result, transfers;
-              if (resultSpec) {
-                result = resultSpec[0];
-                transfers = resultSpec[1];
-              }
-              self._postMessageUp({
-                method: 'response',
-                requestKey: m.requestKey,
-                result,
-              }, transfers);
-            });
+          let result, transfers;
+          if (resultSpec) {
+            result = resultSpec[0];
+            transfers = resultSpec[1];
+          }
+          self._postMessageUp({
+            method: 'response',
+            requestKey: m.requestKey,
+            result,
+          }, transfers);
         } else {
           self._postMessageUp({
             method: 'response',

--- a/src/index.js
+++ b/src/index.js
@@ -453,12 +453,7 @@ const _tickAnimationFrame = win => {
   return win.runAsync({
     method: 'tickAnimationFrame',
     layered: true,
-  })
-    .catch(err => {
-      if (err.code !== 'ECANCEL') {
-        console.warn(err);
-      }
-    });
+  });
 };
 const _tickAnimationFrames = () => {
   for (let i = 0; i < windows.length; i++) {


### PR DESCRIPTION
Fixes https://github.com/exokitxr/exokit-web/issues/49.

This fixes a break in Chrome Canary, where the timing of events changed and `postMessage` on `MessageChannel` is no longer synchronous. The window rendering code depends on this being the case.

Therefore we [make up our own `postMessageSync`](https://github.com/exokitxr/exokit-web/compare/postmessage-sync?expand=1#diff-4b404bfd509e314e13e23e2524a65707R90) and use it as the main cross-window messaging channel.