### PR TITLE
Add docs link in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,12 +173,12 @@ a:active {
           <img src="logo.svg">
           <nav class=selected><span>Viewer</span></nav>
           <a href="http://docs.exokit.org/"><nav><span class="header-link">Documentation</span></nav></a>
-          <nav><span class="coming-soon">Browser
+          <a href="https://discord.gg/UgZDFZW"><nav><span class="coming-soon">Browser
             <p class="coming-soon-sub">Coming soon!</p>
-          </span></nav>
-          <nav><span class="coming-soon">Metaverse
+          </span></nav></a>
+          <a href="https://discord.gg/UgZDFZW"><nav><span class="coming-soon">Metaverse
             <p class="coming-soon-sub">Coming soon!</p>
-          </span></nav>
+          </span></nav></a>
         </header>
 
         <div class=examples>

--- a/index.html
+++ b/index.html
@@ -156,14 +156,14 @@ a:active {
   cursor: auto;
 }
 .coming-soon {
-  color: #AAA;
+  color: #ccc;
 }
 .coming-soon-sub {
   font-size: 10px;
   display: block;
 }
 .header-link {
-  color: #767;
+  color: #666;
 }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -155,6 +155,16 @@ a:active {
   color: #b71c1c;
   cursor: auto;
 }
+.coming-soon {
+  color: #AAA;
+}
+.coming-soon-sub {
+  font-size: 10px;
+  display: block;
+}
+.header-link {
+  color: #767;
+}
     </style>
   </head>
   <body>
@@ -162,9 +172,13 @@ a:active {
         <header>
           <img src="logo.svg">
           <nav class=selected><span>Viewer</span></nav>
-          <nav><span>Browser</span></nav>
-          <nav><span>Metaverse</span></nav>
-          <nav><span><a href="http://docs.exokit.org/">Documentation</a></span></nav>
+          <a href="http://docs.exokit.org/"><nav><span class="header-link">Documentation</span></nav></a>
+          <nav><span class="coming-soon">Browser
+            <p class="coming-soon-sub">Coming soon!</p>
+          </span></nav>
+          <nav><span class="coming-soon">Metaverse
+            <p class="coming-soon-sub">Coming soon!</p>
+          </span></nav>
         </header>
 
         <div class=examples>

--- a/index.html
+++ b/index.html
@@ -164,6 +164,7 @@ a:active {
           <nav class=selected><span>Viewer</span></nav>
           <nav><span>Browser</span></nav>
           <nav><span>Metaverse</span></nav>
+          <nav><span><a href="http://docs.exokit.org/">Documentation</a></span></nav>
         </header>
 
         <div class=examples>


### PR DESCRIPTION
This PR proposes to add a docs link in the header (fixes #72 ):

![docswebbCapture](https://user-images.githubusercontent.com/29695350/64663687-3c704000-d412-11e9-971b-4baca14ff35c.PNG)
