### PR TITLE
Cross-origin loading of sw.js

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,5 @@
-importScripts('./localforage.js');
+const baseUrl = new URL(self.location.href).origin;
+importScripts(`${baseUrl}/localforage.js`);
 
 localforage.config({driver: localforage.INDEXEDDB});
 


### PR DESCRIPTION
Relativize importScripts `localforage.js`. Should fix the `404` on that file.