### PR TITLE
Bugfix highlight gl.BLEND enable/disable

### DIFF
--- a/src/Graphics.js
+++ b/src/Graphics.js
@@ -218,6 +218,14 @@ ProxiedWebGLRenderingContext.prototype._exokitClear = function _exokitClear() {
 ProxiedWebGLRenderingContext.prototype._exokitClearEnabled = function _exokitClearEnabled(enabled) {
   this._enabled.clear = enabled;
 };
+ProxiedWebGLRenderingContext.prototype._exokitEnable = function _exokitEnable(flag) {
+  const gl = GlobalContext.proxyContext;
+  gl.enable(flag);
+};
+ProxiedWebGLRenderingContext.prototype._exokitDisable = function _exokitDisable(flag) {
+  const gl = GlobalContext.proxyContext;
+  gl.disable(flag);
+};
 ProxiedWebGLRenderingContext.prototype._exokitBlendFuncSeparate = function _exokitBlendFuncSeparate(srcRgb, dstRgb, srcAlpha, dstAlpha) {
   const gl = GlobalContext.proxyContext;
   gl.blendFuncSeparate(srcRgb, dstRgb, srcAlpha, dstAlpha);

--- a/src/Window.js
+++ b/src/Window.js
@@ -517,6 +517,7 @@ const _fetchText = src => fetch(src)
       if (context._exokitBlendEnabled) {
         if (highlight) {
           context._exokitBlendEnabled(false);
+          context._exokitEnable(context.BLEND);
           context._exokitBlendFuncSeparate(context.CONSTANT_COLOR, context.ONE_MINUS_SRC_ALPHA, context.CONSTANT_COLOR, context.ONE_MINUS_SRC_ALPHA);
           context._exokitBlendEquationSeparate(context.FUNC_ADD, context.FUNC_ADD);
           context._exokitBlendColor(highlight[0], highlight[1], highlight[2], highlight[3]);


### PR DESCRIPTION
`gl.BLEND` was not enabled during the highlight flow, so depending on XRIframe rendering order the highlighting might not have taken effect.

This introduces the methods needed to make that work and calls them during the highlighting set procedure.