### PR TITLE
LOD support for xr-iframe

### DIFF
--- a/app.html
+++ b/app.html
@@ -93,33 +93,34 @@ const _addGuardian = xrIframe => {
   xrIframe.guardianMeshes = [];
   for (let i = 0; i < xrExtents.length; i++) {
     const xrExtent = xrExtents[i];
-    const sceneColor = 0x9ccc65;
+    if (xrExtent.length > 0) {
+      const sceneColor = 0x9ccc65;
+      const baseMesh = new THREE.Land(xrExtent, sceneColor);
+      baseMesh.updateTransform = function() {
+        this.position.fromArray(xrIframe.position);
+        this.quaternion.fromArray(xrIframe.orientation);
+        this.scale.fromArray(xrIframe.scale);
+      };
+      baseMesh.updateTransform();
+      if (guardianMeshes.length > 0) {
+        _insertBefore(baseMesh, guardianMeshes[0]);
+      } else {
+        scene.add(baseMesh);
+      }
+      xrIframe.baseMeshes.push(baseMesh);
+      baseMeshes.push(baseMesh);
 
-    const baseMesh = new THREE.Land(xrExtent, sceneColor);
-    baseMesh.updateTransform = function() {
-      this.position.fromArray(xrIframe.position);
-      this.quaternion.fromArray(xrIframe.orientation);
-      this.scale.fromArray(xrIframe.scale);
-    };
-    baseMesh.updateTransform();
-    if (guardianMeshes.length > 0) {
-      _insertBefore(baseMesh, guardianMeshes[0]);
-    } else {
-      scene.add(baseMesh);
+      const guardianMesh = new THREE.Guardian(xrExtent, sceneColor);
+      guardianMesh.updateTransform = function() {
+        this.position.fromArray(xrIframe.position);
+        this.quaternion.fromArray(xrIframe.orientation);
+        this.scale.fromArray(xrIframe.scale);
+      };
+      guardianMesh.updateTransform();
+      scene.add(guardianMesh);
+      xrIframe.guardianMeshes.push(guardianMesh);
+      guardianMeshes.push(guardianMesh);
     }
-    xrIframe.baseMeshes.push(baseMesh);
-    baseMeshes.push(baseMesh);
-
-    const guardianMesh = new THREE.Guardian(xrExtent, sceneColor);
-    guardianMesh.updateTransform = function() {
-      this.position.fromArray(xrIframe.position);
-      this.quaternion.fromArray(xrIframe.orientation);
-      this.scale.fromArray(xrIframe.scale);
-    };
-    guardianMesh.updateTransform();
-    scene.add(guardianMesh);
-    xrIframe.guardianMeshes.push(guardianMesh);
-    guardianMeshes.push(guardianMesh);
   }
 };
 const _updateGuardians = () => {

--- a/app.html
+++ b/app.html
@@ -114,7 +114,7 @@ const _addGuardian = xrIframe => {
       xrIframe.baseMeshes.push(baseMesh);
       baseMeshes.push(baseMesh);
 
-      const guardianMesh = new THREE.Guardian(xrExtent, colors.default);
+      const guardianMesh = new THREE.Guardian(xrExtent, 10, colors.default);
       guardianMesh.xrIframe = childXrIframe;
       guardianMesh.updateTransform = function() {
         this.position.fromArray(xrIframe.position);

--- a/app.html
+++ b/app.html
@@ -40,15 +40,11 @@ const _addControls = xrIframe => {
     xrIframe.orientation = object.quaternion.toArray();
     xrIframe.scale = object.scale.toArray();
 
-    if (xrIframe.baseMeshes) {
-      for (let i = 0; i < xrIframe.baseMeshes.length; i++) {
-        xrIframe.baseMeshes[i].updateTransform();
-      }
+    for (let i = 0; i < xrIframe.baseMeshes.length; i++) {
+      xrIframe.baseMeshes[i].updateTransform();
     }
-    if (xrIframe.guardianMeshes) {
-      for (let i = 0; i < xrIframe.guardianMeshes.length; i++) {
-        xrIframe.guardianMeshes[i].updateTransform();
-      }
+    for (let i = 0; i < xrIframe.guardianMeshes.length; i++) {
+      xrIframe.guardianMeshes[i].updateTransform();
     }
   });
   control.addEventListener('dragging-changed', e => {
@@ -89,8 +85,7 @@ const _addGuardian = xrIframe => {
     const extents = xrIframe.getAttribute('extents');
     return extents ? XRIFrame.parseExtents(extents) : [];
   });
-  xrIframe.baseMeshes = [];
-  xrIframe.guardianMeshes = [];
+
   for (let i = 0; i < xrExtents.length; i++) {
     const xrExtent = xrExtents[i];
     if (xrExtent.length > 0) {
@@ -127,8 +122,9 @@ const _updateGuardians = () => {
   const xrIframes = Array.from(root.childNodes).filter(xrIframe => xrIframe instanceof XRIFrame);
   for (let i = 0; i < xrIframes.length; i++) {
     const xrIframe = xrIframes[i];
-    if (!xrIframe.guardianMeshed) {
-      xrIframe.guardianMeshed = true;
+    if (!xrIframe.baseMeshes) {
+      xrIframe.baseMeshes = [];
+      xrIframe.guardianMeshes = [];
 
       if (xrIframe.loaded) {
         _addGuardian(xrIframe);

--- a/app.html
+++ b/app.html
@@ -123,7 +123,7 @@ const _addGuardian = xrIframe => {
   }
 };
 const _updateGuardians = () => {
-  const xrIframes = Array.from(root.childNodes);
+  const xrIframes = Array.from(root.childNodes).filter(xrIframe => xrIframe instanceof XRIFrame);
   for (let i = 0; i < xrIframes.length; i++) {
     const xrIframe = xrIframes[i];
     if (!xrIframe.guardianMeshed) {
@@ -227,10 +227,23 @@ function animate() {
   const _updateVrCamera = () => {
     vrCamera.matrixWorldInverse.fromArray(root.viewMatrix);
     vrCamera.matrixWorld.getInverse(vrCamera.matrixWorldInverse);
+
     vrCamera.projectionMatrix.fromArray(root.projectionMatrix);
     vrCamera.projectionMatrixInverse.getInverse(vrCamera.projectionMatrix);
+
+    vrCamera.matrixWorld.decompose(vrCamera.position, vrCamera.quaternion, vrCamera.scale);
   };
   _updateVrCamera();
+
+  const xrIframes = Array.from(root.childNodes).filter(xrIframe => xrIframe instanceof XRIFrame);
+  for (let i = 0; i < xrIframes.length; i++) {
+    const xrIframe = xrIframes[i];
+    const childXrIframes = _getChildXrIframes(xrIframe);
+    if (childXrIframes.length > 1) {
+      const contains = childXrIframes.map(xrIframe => xrIframe.contains(vrCamera.position.toArray()));
+      // console.log('got contains', childXrIframes[0].position, contains);
+    }
+  }
 
   renderer.render(scene, camera);
 }

--- a/app.html
+++ b/app.html
@@ -230,20 +230,8 @@ function animate() {
 
     vrCamera.projectionMatrix.fromArray(root.projectionMatrix);
     vrCamera.projectionMatrixInverse.getInverse(vrCamera.projectionMatrix);
-
-    vrCamera.matrixWorld.decompose(vrCamera.position, vrCamera.quaternion, vrCamera.scale);
   };
   _updateVrCamera();
-
-  const xrIframes = Array.from(root.childNodes).filter(xrIframe => xrIframe instanceof XRIFrame);
-  for (let i = 0; i < xrIframes.length; i++) {
-    const xrIframe = xrIframes[i];
-    const childXrIframes = _getChildXrIframes(xrIframe);
-    if (childXrIframes.length > 1) {
-      const contains = childXrIframes.map(xrIframe => xrIframe.contains(vrCamera.position.toArray()));
-      // console.log('got contains', childXrIframes[0].position, contains);
-    }
-  }
 
   renderer.render(scene, camera);
 }

--- a/app.html
+++ b/app.html
@@ -79,6 +79,10 @@ const _insertBefore = (a, b) => {
   const bIndex = scene.children.indexOf(b);
   scene.children.splice(bIndex, 0, a);
 };
+const colors = {
+  default: 0x42a5f5,
+  highlight: 0x9ccc65,
+};
 const _addGuardian = xrIframe => {
   const childXrIframes = _getChildXrIframes(xrIframe);
   const xrExtents = childXrIframes.map(xrIframe => {
@@ -89,12 +93,17 @@ const _addGuardian = xrIframe => {
   for (let i = 0; i < xrExtents.length; i++) {
     const xrExtent = xrExtents[i];
     if (xrExtent.length > 0) {
-      const sceneColor = 0x9ccc65;
-      const baseMesh = new THREE.Land(xrExtent, sceneColor);
+      const childXrIframe = childXrIframes[i];
+      const baseMesh = new THREE.Land(xrExtent, colors.default);
+      baseMesh.xrIframe = childXrIframe;
       baseMesh.updateTransform = function() {
         this.position.fromArray(xrIframe.position);
         this.quaternion.fromArray(xrIframe.orientation);
         this.scale.fromArray(xrIframe.scale);
+        this.updateColor();
+      };
+      baseMesh.updateColor = function() {
+        this.setColor(this.xrIframe.visible ? colors.highlight : colors.default);
       };
       baseMesh.updateTransform();
       if (guardianMeshes.length > 0) {
@@ -105,11 +114,16 @@ const _addGuardian = xrIframe => {
       xrIframe.baseMeshes.push(baseMesh);
       baseMeshes.push(baseMesh);
 
-      const guardianMesh = new THREE.Guardian(xrExtent, sceneColor);
+      const guardianMesh = new THREE.Guardian(xrExtent, colors.default);
+      guardianMesh.xrIframe = childXrIframe;
       guardianMesh.updateTransform = function() {
         this.position.fromArray(xrIframe.position);
         this.quaternion.fromArray(xrIframe.orientation);
         this.scale.fromArray(xrIframe.scale);
+        this.updateColor();
+      };
+      guardianMesh.updateColor = function() {
+        this.setColor(this.xrIframe.visible ? colors.highlight : colors.default);
       };
       guardianMesh.updateTransform();
       scene.add(guardianMesh);
@@ -118,7 +132,7 @@ const _addGuardian = xrIframe => {
     }
   }
 };
-const _updateGuardians = () => {
+const _refreshGuardians = () => {
   const xrIframes = Array.from(root.childNodes).filter(xrIframe => xrIframe instanceof XRIFrame);
   for (let i = 0; i < xrIframes.length; i++) {
     const xrIframe = xrIframes[i];
@@ -138,12 +152,10 @@ const _updateGuardians = () => {
     }
   }
   for (let i = 0; i < baseMeshes.length; i++) {
-    const baseMesh = baseMeshes[i];
-    baseMesh.updateTransform();
+    baseMeshes[i].updateTransform();
   }
   for (let i = 0; i < guardianMeshes.length; i++) {
-    const guardianMesh = guardianMeshes[i];
-    guardianMesh.updateTransform();
+    guardianMeshes[i].updateTransform();
   }
 };
 const _postTabs = () => {
@@ -207,7 +219,7 @@ root.layers.push(renderer.domElement);
 _addControls(floorXrIframe);
 _addControls(tutorialXrIframe);
 _addControls(subsceneXrIframe);
-_updateGuardians();
+_refreshGuardians();
 _postTabs();
 
 function animate() {
@@ -227,8 +239,20 @@ function animate() {
 
     vrCamera.projectionMatrix.fromArray(root.projectionMatrix);
     vrCamera.projectionMatrixInverse.getInverse(vrCamera.projectionMatrix);
+
+    vrCamera.matrixWorld.decompose(vrCamera.position, vrCamera.quaternion, vrCamera.scale);
   };
   _updateVrCamera();
+
+  const _updateGuardians = () => {
+    for (let i = 0; i < baseMeshes.length; i++) {
+      baseMeshes[i].updateColor();
+    }
+    for (let i = 0; i < guardianMeshes.length; i++) {
+      guardianMeshes[i].updateColor();
+    }
+  };
+  _updateGuardians();
 
   renderer.render(scene, camera);
 }
@@ -293,7 +317,7 @@ window.addEventListener('message', e => {
         root.appendChild(xrIframe);
       }
       _cleanupRoot();
-      _updateGuardians();
+      _refreshGuardians();
       _postTabs();
 
       break;
@@ -312,7 +336,7 @@ window.addEventListener('message', e => {
         scene.remove(xrIframe.guardianMeshes[i]);
       }
       _cleanupRoot();
-      _updateGuardians();
+      _refreshGuardians();
       _postTabs();
 
       break;
@@ -334,7 +358,7 @@ window.addEventListener('message', e => {
       if (match) {
         root.innerHTML = /\S/.test(match[1]) ? match[1] : '';
       }
-      _updateGuardians();
+      _refreshGuardians();
       _postTabs();
       break;
     }

--- a/app.html
+++ b/app.html
@@ -305,6 +305,12 @@ window.addEventListener('message', e => {
         xrIframe.parentNode.removeChild(xrIframe.previousSibling);
       }
       xrIframe.parentNode.removeChild(xrIframe);
+      for (let i = 0; i < xrIframe.baseMeshes.length; i++) {
+        scene.remove(xrIframe.baseMeshes[i]);
+      }
+      for (let i = 0; i < xrIframe.guardianMeshes.length; i++) {
+        scene.remove(xrIframe.guardianMeshes[i]);
+      }
       _cleanupRoot();
       _updateGuardians();
       _postTabs();

--- a/app.html
+++ b/app.html
@@ -69,6 +69,13 @@ const _addControls = xrIframe => {
 const _removeControls = xrIframe => {
   scene.remove(xrIframe.control);
 };
+const _getChildXrIframes = xrIframe => {
+  const contentDocument = xrIframe.contentWindow.iframe.contentDocument;
+  return Array.from(xrIframe)
+    .concat(
+      Array.from(contentDocument.querySelectorAll('xr-iframe'))
+    );
+};
 const _insertBefore = (a, b) => {
   scene.add(a);
   const aIndex = scene.children.indexOf(a);
@@ -77,11 +84,7 @@ const _insertBefore = (a, b) => {
   scene.children.splice(bIndex, 0, a);
 };
 const _addGuardian = xrIframe => {
-  const contentDocument = xrIframe.contentWindow.iframe.contentDocument;
-  const childXrIframes = Array.from(xrIframe)
-    .concat(
-      Array.from(contentDocument.querySelectorAll('template')).flatMap(template => Array.from(template.content.querySelectorAll('xr-iframe')))
-    );
+  const childXrIframes = _getChildXrIframes(xrIframe);
   const xrExtents = childXrIframes.map(xrIframe => {
     const extents = xrIframe.getAttribute('extents');
     return extents ? XRIFrame.parseExtents(extents) : [];

--- a/land.js
+++ b/land.js
@@ -12,7 +12,7 @@ const boxGeometry = THREE.BufferGeometryUtils.mergeBufferGeometries([
   leftGeometry.clone().applyMatrix(new THREE.Matrix4().makeTranslation(0, -0.5, -0.5)),
 ]);
 
-THREE.Guardian = function Guardian(extents, color) {
+THREE.Guardian = function Guardian(extents, distanceFactor, color) {
   const _makeGeometry = () => {
     const pixels = {};
     for (let i = 0; i < extents.length; i++) {
@@ -82,7 +82,7 @@ THREE.Guardian = function Guardian(extents, color) {
       gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.);
       // vUv = uv;
       vWorldPos = abs(position);
-      vDepth = gl_Position.z / 2.0;
+      vDepth = gl_Position.z / ${distanceFactor.toFixed(8)};
     }
   `;
   const gridFsh = `

--- a/land.js
+++ b/land.js
@@ -87,15 +87,20 @@ THREE.Guardian = function Guardian(extents, color) {
   `;
   const gridFsh = `
     // uniform sampler2D uTex;
+    uniform vec3 uColor;
     uniform float uAnimation;
     varying vec3 vWorldPos;
     varying float vDepth;
     void main() {
-      gl_FragColor = vec4(${new THREE.Color(color/*0x5c6bc0*/).toArray().map(n => n.toFixed(8)).join(',')}, (1.0-vDepth)*uAnimation);
+      gl_FragColor = vec4(uColor, (1.0-vDepth)*uAnimation);
     }
   `;
   const material = new THREE.ShaderMaterial({
     uniforms: {
+      uColor: {
+        type: 'c',
+        value: new THREE.Color(color),
+      },
       uAnimation: {
         type: 'f',
         value: 1,
@@ -107,6 +112,9 @@ THREE.Guardian = function Guardian(extents, color) {
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.frustumCulled = false;
+  mesh.setColor = c => {
+    mesh.material.uniforms.uColor.value.setHex(c);
+  };
   return mesh;
 };
 
@@ -136,13 +144,18 @@ THREE.Land = function Land(extents, color) {
     }
   `;
   const baseFsh = `
+    uniform vec3 uColor;
     uniform float uAnimation;
     void main() {
-      gl_FragColor = vec4(${new THREE.Color(color/*0x5c6bc0*/).toArray().map(n => n.toFixed(8)).join(',')}, uAnimation*0.5);
+      gl_FragColor = vec4(uColor, uAnimation*0.5);
     }
   `;
   const material = new THREE.ShaderMaterial({
     uniforms: {
+      uColor: {
+        type: 'c',
+        value: new THREE.Color(color),
+      },
       uAnimation: {
         type: 'f',
         value: 1,
@@ -155,6 +168,9 @@ THREE.Land = function Land(extents, color) {
   });
   const mesh = new THREE.Mesh(geometry, material);
   mesh.frustumCulled = false;
+  mesh.setColor = c => {
+    mesh.material.uniforms.uColor.value.setHex(c);
+  };
   return mesh;
 };
 THREE.Land.parseExtents = s => {

--- a/src/Window.js
+++ b/src/Window.js
@@ -550,7 +550,9 @@ const _fetchText = src => fetch(src)
       const layer = vrPresentState.layers[i];
       const contentWindow = layer && layer.contentWindow;
       if (contentWindow) {
-         _renderChild(contentWindow, true, highlight || contentWindow.highlight);
+        if (!(layer instanceof XRIFrame) || layer.visible) {
+          _renderChild(contentWindow, true, highlight || contentWindow.highlight);
+        }
         contentWindow.rendered = true;
       }
     }

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -255,33 +255,31 @@ class XRIFrame extends HTMLElement {
     this._loadFactor = loadFactor;
   }
 
-  contains(position) {
-    if (Array.isArray(position) && position.length === 3 && position.every(n => isFinite(n))) {
-      localVector
-        .fromArray(position)
-        .applyMatrix4(
-          localMatrix
-            .copy(GlobalContext.getXrOffsetMatrix())
-            .getInverse(localMatrix)
-        );
-      const {extents, loadFactor} = this;
-      if (extents.length > 0 && isFinite(loadFactor)) {
-        return extents.some(([x1, y1, x2, y2]) => {
-          const cx = (x1 + x2) / 2;
-          const cy = (y1 + y2) / 2;
-          const sx = (x2 - x1) * loadFactor;
-          const sy = (y2 - y1) * loadFactor;
-          const minX = cx - sx/2;
-          const minY = cy - sy/2;
-          const maxX = cx + sx/2;
-          const maxY = cy + sy/2;
-          return localVector.x >= minX && localVector.z >= minY && localVector.x < maxX && localVector.z < maxY;
-        });
-      } else {
-        return true;
-      }
+  get visible() {
+    localVector
+      .fromArray(GlobalContext.xrState.position)
+      .applyMatrix4(
+        localMatrix
+          .copy(GlobalContext.getXrOffsetMatrix())
+          .getInverse(localMatrix)
+      );
+    const {extents, loadFactor} = this;
+    if (extents.length > 0 && isFinite(loadFactor)) {
+      return extents.some(([x1, y1, x2, y2]) => {
+        x2++;
+        y2++;
+        const cx = (x1 + x2) / 2;
+        const cy = (y1 + y2) / 2;
+        const sx = (x2 - x1) * loadFactor;
+        const sy = (y2 - y1) * loadFactor;
+        const minX = cx - sx/2;
+        const minY = cy - sy/2;
+        const maxX = cx + sx/2;
+        const maxY = cy + sy/2;
+        return localVector.x >= minX && localVector.z >= minY && localVector.x < maxX && localVector.z < maxY;
+      });
     } else {
-      return false;
+      return true;
     }
   }
 

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -41,7 +41,7 @@ class XRIFrame extends HTMLElement {
     this.xrOffset = new XRRigidTransform();
     this._highlight = null;
     this._extents = [];
-    this._loadFactor = Infinity;
+    this._loadDistance = Infinity;
   }
   async attributeChangedCallback(name, oldValue, newValue) {
     await GlobalContext.loadPromise;
@@ -155,10 +155,10 @@ class XRIFrame extends HTMLElement {
       }
     } else if (name === 'extents') {
       this.extents = parseExtents(newValue);
-    } else if (name === 'load-factor') {
-      const loadFactor = parseFloat(newValue);
-      if (isFinite(loadFactor)) {
-        this.loadFactor = loadFactor;
+    } else if (name === 'load-distance') {
+      const loadDistance = parseFloat(newValue);
+      if (isFinite(loadDistance)) {
+        this.loadDistance = loadDistance;
       }
     }
   }
@@ -170,7 +170,7 @@ class XRIFrame extends HTMLElement {
       'scale',
       'highlight',
       'extents',
-      'load-factor',
+      'load-distance',
     ];
   }
   get src() {
@@ -248,11 +248,11 @@ class XRIFrame extends HTMLElement {
     this._extents = extents;
   }
 
-  get loadFactor() {
-    return this._loadFactor;
+  get loadDistance() {
+    return this._loadDistance;
   }
-  set loadFactor(loadFactor) {
-    this._loadFactor = loadFactor;
+  set loadDistance(loadDistance) {
+    this._loadDistance = loadDistance;
   }
 
   get visible() {
@@ -263,15 +263,15 @@ class XRIFrame extends HTMLElement {
           .copy(GlobalContext.getXrOffsetMatrix())
           .getInverse(localMatrix)
       );
-    const {extents, loadFactor} = this;
-    if (extents.length > 0 && isFinite(loadFactor)) {
+    const {extents, loadDistance} = this;
+    if (extents.length > 0 && isFinite(loadDistance)) {
       return extents.some(([x1, y1, x2, y2]) => {
         x2++;
         y2++;
         const cx = (x1 + x2) / 2;
         const cy = (y1 + y2) / 2;
-        const sx = (x2 - x1) * loadFactor;
-        const sy = (y2 - y1) * loadFactor;
+        const sx = x2 - x1 + loadDistance * 2;
+        const sy = y2 - y1 + loadDistance * 2;
         const minX = cx - sx/2;
         const minY = cy - sy/2;
         const maxX = cx + sx/2;


### PR DESCRIPTION
![lol9](https://user-images.githubusercontent.com/6926057/65948890-1df5d700-e409-11e9-92e9-ba05d327a9bf.gif)

This adds LOD visibility for `xr-iframe`'s `extents`. It honors the `extents` and `load-distance` for `xr-iframe` at the engine level, and also accounts for layered XROffset transforms:

```
<xr-iframe position="7 0 7" extents="[0 0 15 15]" load-factor=1 src="app1.html"></xr-iframe>
```

The default remains visibility for all `xr-iframe`s and the default `load-distance` is `Infinity`. `load-distance` of `0` means exactly the `extents` bound, while `load-distance === 10` means load when `<= 10` units away.