### PR TITLE
Add xrOffset epoch tracking

### DIFF
--- a/ew.js
+++ b/ew.js
@@ -81,6 +81,7 @@ const xrState = (() => {
   result.leftFov.set(Float32Array.from([45, 45, 45, 45]));
   result.rightFov = _makeTypedArray(Float32Array, 4);
   result.rightFov.set(result.leftFov);
+  result.offsetEpoch = _makeTypedArray(Uint32Array, 1);
   const _makeGamepad = () => ({
     connected: _makeTypedArray(Uint32Array, 1),
     position: _makeTypedArray(Float32Array, 3),

--- a/src/VR.js
+++ b/src/VR.js
@@ -27,7 +27,7 @@ const localVector = new THREE.Vector3();
 const localVector2 = new THREE.Vector3();
 const localQuaternion = new THREE.Quaternion();
 const localMatrix = new THREE.Matrix4();
-// const localMatrix2 = new THREE.Matrix4();
+const localMatrix2 = new THREE.Matrix4();
 const localXrOffsetMatrix = new THREE.Matrix4();
 const localXrOffsetMatrix2 = new THREE.Matrix4();
 
@@ -185,11 +185,16 @@ class VRStageParameters {
   } */
 }
 
+let localOffsetEpoch = 0;
 function getXrOffsetMatrix() {
-  let win = window;
-  localXrOffsetMatrix.fromArray(win.document.xrOffset.matrix);
-  for (win = win.parent; win.parent !== win; win = win.parent) {
-    localXrOffsetMatrix.premultiply(localXrOffsetMatrix2.fromArray(win.document.xrOffset.matrix));
+  const offsetEpoch = GlobalContext.xrState.offsetEpoch[0];
+  if (localOffsetEpoch !== offsetEpoch) {
+    let win = window;
+    localXrOffsetMatrix.fromArray(win.document.xrOffset.matrix);
+    for (win = win.parent; win.parent !== win; win = win.parent) {
+      localXrOffsetMatrix.premultiply(localXrOffsetMatrix2.fromArray(win.document.xrOffset.matrix));
+    }
+    localOffsetEpoch = offsetEpoch;
   }
   return localXrOffsetMatrix;
 }
@@ -244,7 +249,7 @@ class VRDisplay extends EventTarget {
     localMatrix
       .compose(localVector.fromArray(GlobalContext.xrState.position), localQuaternion.fromArray(GlobalContext.xrState.orientation), localVector2.set(1, 1, 1))
       .premultiply(
-        xrOffsetMatrix.getInverse(xrOffsetMatrix)
+        localMatrix2.getInverse(xrOffsetMatrix)
       )
       .decompose(localVector, localQuaternion, localVector2);
     localVector.toArray(frameData.pose.position);

--- a/src/XR.js
+++ b/src/XR.js
@@ -335,18 +335,14 @@ class XRWebGLLayer {
 }
 
 const _applyXrOffsetToPose = (pose, xrOffsetMatrix, inverse, premultiply) => {
-  localMatrix
-    .fromArray(pose._realViewMatrix);
-  if (inverse) {
-    xrOffsetMatrix.getInverse(xrOffsetMatrix);
-  }
+  localMatrix.fromArray(pose._realViewMatrix);
+  const inverseXrOffsetMatrix = inverse ? localMatrix2.getInverse(xrOffsetMatrix) : xrOffsetMatrix;
   if (premultiply) {
-    localMatrix.premultiply(xrOffsetMatrix);
+    localMatrix.premultiply(inverseXrOffsetMatrix);
   } else {
-    localMatrix.multiply(xrOffsetMatrix);
+    localMatrix.multiply(inverseXrOffsetMatrix);
   }
-  localMatrix
-    .toArray(pose._localViewMatrix);
+  localMatrix.toArray(pose._localViewMatrix);
 };
 
 class XRFrame {
@@ -634,6 +630,8 @@ class XRRigidTransform {
     localVector.toArray(this.positionInverse);
     localQuaternion.toArray(this.orientationInverse);
     localVector2.toArray(this.scaleInverse);
+
+    GlobalContext.xrState.offsetEpoch[0]++;
   }
 }
 


### PR DESCRIPTION
This PR optimizes xr offset computation to happen at most once per xrOffset change, per `xr-iframe`. The main reason for doing this is to handle the expensive case where many calls to `getXrOffsetMatrix` are made per frame.

Additionally, we now enusure that the result of `getXrOffsetMatrix` is re-entrant and callers are not destroying it by, for example, inverting it in-place.