### PR TITLE
xrOffset child -> parent

### DIFF
--- a/src/Window.js
+++ b/src/Window.js
@@ -762,7 +762,8 @@ const _fetchText = src => fetch(src)
   const xrOffset = options.xrOffsetBuffer ? new XR.XRRigidTransform(options.xrOffsetBuffer) : new XR.XRRigidTransform();
   xrOffset.addEventListener('change', e => {
     self._postMessageUp({
-      method: 'xrOffsetChange',
+      method: 'emit',
+      type: 'xrOffsetChange',
       event: e.detail,
     });
   });

--- a/src/Window.js
+++ b/src/Window.js
@@ -759,7 +759,14 @@ const _fetchText = src => fetch(src)
     document.childNodes.removeChild(document.childNodes[i]);
   } */
 
-  window.document.xrOffset = options.xrOffsetBuffer ? new XR.XRRigidTransform(options.xrOffsetBuffer) : new XR.XRRigidTransform();
+  const xrOffset = options.xrOffsetBuffer ? new XR.XRRigidTransform(options.xrOffsetBuffer) : new XR.XRRigidTransform();
+  xrOffset.addEventListener('change', e => {
+    self._postMessageUp({
+      method: 'xrOffsetChange',
+      event: e.detail,
+    });
+  });
+  window.document.xrOffset = xrOffset;
 
   /* {
     const _insertAfter = s => {

--- a/src/WindowVm.js
+++ b/src/WindowVm.js
@@ -325,6 +325,9 @@ const _makeWindow = (options = {}) => {
   window.addEventListener('paymentRequest', e => {
     options.onpaymentrequest && options.onpaymentrequest(e.detail);
   });
+  window.addEventListener('xrOffsetChange', e => {
+    options.onxroffsetchange && options.onxroffsetchange(e.detail);
+  });
   window.addEventListener('load', () => {
     window.loaded = true;
   }, {

--- a/src/XR.js
+++ b/src/XR.js
@@ -517,7 +517,7 @@ class XRInputSourceEvent extends Event {
 }
 GlobalContext.XRInputSourceEvent = XRInputSourceEvent;
 
-class XRRigidTransform extends EventEmitter {
+class XRRigidTransform extends EventTarget {
   constructor(position, orientation, scale) {
     if (typeof position == 'object') {
       const inverse = orientation instanceof XRRigidTransform ? orientation : null;

--- a/src/XR.js
+++ b/src/XR.js
@@ -519,6 +519,8 @@ GlobalContext.XRInputSourceEvent = XRInputSourceEvent;
 
 class XRRigidTransform extends EventTarget {
   constructor(position, orientation, scale) {
+    super();
+
     if (typeof position == 'object') {
       const inverse = orientation instanceof XRRigidTransform ? orientation : null;
 

--- a/src/XR.js
+++ b/src/XR.js
@@ -686,6 +686,10 @@ class XRRigidTransform extends EventEmitter {
 
     GlobalContext.xrState.offsetEpoch[0]++;
   }
+
+  /* pushEvent() {
+    this.dispatchEvent(new CustomEvent('change'));
+  } */
 }
 
 class XRSpace extends EventTarget {

--- a/src/XR.js
+++ b/src/XR.js
@@ -542,30 +542,30 @@ class XRRigidTransform extends EventEmitter {
         scale = {x: 1, y: 1, z: 1};
       }
 
-      this.position[0] = position.x;
-      this.position[1] = position.y;
-      this.position[2] = position.z;
+      this._position[0] = position.x;
+      this._position[1] = position.y;
+      this._position[2] = position.z;
 
-      this.orientation[0] = orientation.x;
-      this.orientation[1] = orientation.y;
-      this.orientation[2] = orientation.z;
-      this.orientation[3] = orientation.w;
+      this._orientation[0] = orientation.x;
+      this._orientation[1] = orientation.y;
+      this._orientation[2] = orientation.z;
+      this._orientation[3] = orientation.w;
 
-      this.scale[0] = scale.x;
-      this.scale[1] = scale.y;
-      this.scale[2] = scale.z;
+      this._scale[0] = scale.x;
+      this._scale[1] = scale.y;
+      this._scale[2] = scale.z;
 
       localMatrix
-        .compose(localVector.fromArray(this.position), localQuaternion.fromArray(this.orientation), localVector2.fromArray(this.scale))
+        .compose(localVector.fromArray(this._position), localQuaternion.fromArray(this._orientation), localVector2.fromArray(this._scale))
         .toArray(this.matrix);
       localMatrix
         .getInverse(localMatrix)
         .toArray(this.matrixInverse);
       localMatrix
         .decompose(localVector, localQuaternion, localVector2);
-      localVector.toArray(this.positionInverse);
-      localQuaternion.toArray(this.orientationInverse);
-      localVector2.toArray(this.scaleInverse);
+      localVector.toArray(this._positionInverse);
+      localQuaternion.toArray(this._orientationInverse);
+      localVector2.toArray(this._scaleInverse);
     }
 
     if (!this._inverse) {
@@ -580,13 +580,13 @@ class XRRigidTransform extends EventEmitter {
     {
       let index = this._inverse ? ((3 + 4 + 3 + 16) * Float32Array.BYTES_PER_ELEMENT) : 0;
 
-      this.position = new Float32Array(this._buffer, index, 3);
+      this._position = new Float32Array(this._buffer, index, 3);
       index += 3 * Float32Array.BYTES_PER_ELEMENT;
 
-      this.orientation = new Float32Array(this._buffer, index, 4);
+      this._orientation = new Float32Array(this._buffer, index, 4);
       index += 4 * Float32Array.BYTES_PER_ELEMENT;
 
-      this.scale = new Float32Array(this._buffer, index, 3);
+      this._scale = new Float32Array(this._buffer, index, 3);
       index += 3 * Float32Array.BYTES_PER_ELEMENT;
 
       this.matrix = new Float32Array(this._buffer, index, 16);
@@ -595,13 +595,13 @@ class XRRigidTransform extends EventEmitter {
     {
       let index = this._inverse ? 0 : ((3 + 4 + 3 + 16) * Float32Array.BYTES_PER_ELEMENT);
 
-      this.positionInverse = new Float32Array(this._buffer, index, 3);
+      this._positionInverse = new Float32Array(this._buffer, index, 3);
       index += 3 * Float32Array.BYTES_PER_ELEMENT;
 
-      this.orientationInverse = new Float32Array(this._buffer, index, 4);
+      this._orientationInverse = new Float32Array(this._buffer, index, 4);
       index += 4 * Float32Array.BYTES_PER_ELEMENT;
 
-      this.scaleInverse = new Float32Array(this._buffer, index, 3);
+      this._scaleInverse = new Float32Array(this._buffer, index, 3);
       index += 3 * Float32Array.BYTES_PER_ELEMENT;
 
       this.matrixInverse = new Float32Array(this._buffer, index, 16);
@@ -614,12 +614,65 @@ class XRRigidTransform extends EventEmitter {
   }
   set inverse(inverse) {}
 
+  get position() {
+    return this._position;
+  }
+  set position(position) {
+    /* this._position[0] = position[0];
+    this._position[1] = position[1];
+    this._position[2] = position[2];
+
+    this.pushUpdate();
+    this.pushEvent(); */
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: {
+        key: 'position',
+        value: position,
+      },
+    });
+  }
+  get orientation() {
+    return this._orientation;
+  }
+  set orientation(orientation) {
+    /* this._orientation[0] = orientation[0];
+    this._orientation[1] = orientation[1];
+    this._orientation[2] = orientation[2];
+    this._orientation[3] = orientation[3];
+
+    this.pushUpdate();
+    this.pushEvent(); */
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: {
+        key: 'orientation',
+        value: orientation,
+      },
+    });
+  }
+  get scale() {
+    return this._scale;
+  }
+  set scale(scale) {
+    /* this._scale[0] = scale[0];
+    this._scale[1] = scale[1];
+    this._scale[2] = scale[2];
+
+    this.pushUpdate();
+    this.pushEvent(); */
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: {
+        key: 'scale',
+        value: scale,
+      },
+    });
+  }
+
   pushUpdate() {
     localMatrix
       .compose(
-        localVector.fromArray(this.position),
-        localQuaternion.fromArray(this.orientation),
-        localVector2.fromArray(this.scale)
+        localVector.fromArray(this._position),
+        localQuaternion.fromArray(this._orientation),
+        localVector2.fromArray(this._scale)
       )
       .toArray(this.matrix);
     localMatrix
@@ -627,9 +680,9 @@ class XRRigidTransform extends EventEmitter {
       .toArray(this.matrixInverse);
     localMatrix
       .decompose(localVector, localQuaternion, localVector2);
-    localVector.toArray(this.positionInverse);
-    localQuaternion.toArray(this.orientationInverse);
-    localVector2.toArray(this.scaleInverse);
+    localVector.toArray(this._positionInverse);
+    localQuaternion.toArray(this._orientationInverse);
+    localVector2.toArray(this._scaleInverse);
 
     GlobalContext.xrState.offsetEpoch[0]++;
   }

--- a/src/XR.js
+++ b/src/XR.js
@@ -629,7 +629,7 @@ class XRRigidTransform extends EventEmitter {
         key: 'position',
         value: position,
       },
-    });
+    }));
   }
   get orientation() {
     return this._orientation;

--- a/src/XR.js
+++ b/src/XR.js
@@ -618,12 +618,6 @@ class XRRigidTransform extends EventEmitter {
     return this._position;
   }
   set position(position) {
-    /* this._position[0] = position[0];
-    this._position[1] = position[1];
-    this._position[2] = position[2];
-
-    this.pushUpdate();
-    this.pushEvent(); */
     this.dispatchEvent(new CustomEvent('change', {
       detail: {
         key: 'position',
@@ -635,13 +629,6 @@ class XRRigidTransform extends EventEmitter {
     return this._orientation;
   }
   set orientation(orientation) {
-    /* this._orientation[0] = orientation[0];
-    this._orientation[1] = orientation[1];
-    this._orientation[2] = orientation[2];
-    this._orientation[3] = orientation[3];
-
-    this.pushUpdate();
-    this.pushEvent(); */
     this.dispatchEvent(new CustomEvent('change', {
       detail: {
         key: 'orientation',
@@ -653,12 +640,6 @@ class XRRigidTransform extends EventEmitter {
     return this._scale;
   }
   set scale(scale) {
-    /* this._scale[0] = scale[0];
-    this._scale[1] = scale[1];
-    this._scale[2] = scale[2];
-
-    this.pushUpdate();
-    this.pushEvent(); */
     this.dispatchEvent(new CustomEvent('change', {
       detail: {
         key: 'scale',
@@ -686,10 +667,6 @@ class XRRigidTransform extends EventEmitter {
 
     GlobalContext.xrState.offsetEpoch[0]++;
   }
-
-  /* pushEvent() {
-    this.dispatchEvent(new CustomEvent('change'));
-  } */
 }
 
 class XRSpace extends EventTarget {

--- a/src/XR.js
+++ b/src/XR.js
@@ -634,7 +634,7 @@ class XRRigidTransform extends EventEmitter {
         key: 'orientation',
         value: orientation,
       },
-    });
+    }));
   }
   get scale() {
     return this._scale;
@@ -645,7 +645,7 @@ class XRRigidTransform extends EventEmitter {
         key: 'scale',
         value: scale,
       },
-    });
+    }));
   }
 
   pushUpdate() {

--- a/src/XR.js
+++ b/src/XR.js
@@ -517,7 +517,7 @@ class XRInputSourceEvent extends Event {
 }
 GlobalContext.XRInputSourceEvent = XRInputSourceEvent;
 
-class XRRigidTransform {
+class XRRigidTransform extends EventEmitter {
   constructor(position, orientation, scale) {
     if (typeof position == 'object') {
       const inverse = orientation instanceof XRRigidTransform ? orientation : null;

--- a/src/core.js
+++ b/src/core.js
@@ -55,6 +55,7 @@ exokit.load = (src, options = {}) => {
     onpointerlock: options.onpointerlock,
     onhapticpulse: options.onhapticpulse,
     onpaymentrequest: options.onpaymentrequest,
+    onxroffsetchange: options.onxroffsetchange,
   });
 };
 exokit.setArgs = newArgs => {

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -108,6 +108,16 @@ class XRIFrame extends HTMLElement {
               });
             }
           },
+          onxroffsetchange(event) {
+            const {key, value} = event.detail;
+            if (key === 'position') {
+              this.position = value;
+            } else if (key === 'orientation') {
+              this.orientation = value;
+            } else if (key === 'scale') {
+              this.scale = value;
+            }
+          },
         });
         win.highlight = this._highlight;
         win.addEventListener('load', () => {

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -108,14 +108,17 @@ class XRIFrame extends HTMLElement {
               });
             }
           },
-          onxroffsetchange(event) {
-            const {key, value} = event.detail;
+          onxroffsetchange: event => {
+            const {key, value} = event;
             if (key === 'position') {
-              this.position = value;
+              this.xrOffset._position.set(value);
+              this.xrOffset.pushUpdate();
             } else if (key === 'orientation') {
-              this.orientation = value;
+              this.xrOffset._orientation.set(value);
+              this.xrOffset.pushUpdate();
             } else if (key === 'scale') {
-              this.scale = value;
+              this.xrOffset._scale.set(value);
+              this.xrOffset.pushUpdate();
             }
           },
         });

--- a/src/xr-iframe.js
+++ b/src/xr-iframe.js
@@ -126,7 +126,7 @@ class XRIFrame extends HTMLElement {
       if (position.length === 3) {
         position = position.map(s => parseFloat(s));
         if (position.every(n => isFinite(n))) {
-          this.xrOffset.position.set(position);
+          this.xrOffset._position.set(position);
           this.xrOffset.pushUpdate();
         }
       }
@@ -135,7 +135,7 @@ class XRIFrame extends HTMLElement {
       if (orientation.length === 4) {
         orientation = orientation.map(s => parseFloat(s));
         if (orientation.every(n => isFinite(n))) {
-          this.xrOffset.orientation.set(orientation);
+          this.xrOffset._orientation.set(orientation);
           this.xrOffset.pushUpdate();
         }
       }
@@ -144,7 +144,7 @@ class XRIFrame extends HTMLElement {
       if (scale.length === 3) {
         scale = scale.map(s => parseFloat(s));
         if (scale.every(n => isFinite(n))) {
-          this.xrOffset.scale.set(scale);
+          this.xrOffset._scale.set(scale);
           this.xrOffset.pushUpdate();
         }
       }


### PR DESCRIPTION
This adds support for the child `xr-iframe` communicating its transform to the parent, via the `window.document.xrOffset`.

This allows a child to maneuver itself in the parent space, which is useful for item-like AR iframes.